### PR TITLE
Markdown support for page bodies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source :rubygems
 gem "haml"
+gem "rdiscount"

--- a/lib/page_template.html.haml
+++ b/lib/page_template.html.haml
@@ -24,4 +24,7 @@
             %a{:href => "#{page}.html"}= page
     .main
       %h2= title
-      %pre= body
+      - if markdown
+        != body.to_html
+      - else
+        %pre= body

--- a/lib/soywiki.rb
+++ b/lib/soywiki.rb
@@ -22,7 +22,12 @@ called main/HomePage.
 END
       exit
     elsif ARGV.first == '--html'
-      self.html_export 
+      if ARGV[1] == '--markdown'
+        puts "got true"
+        self.html_export(true)
+      else
+        self.html_export
+      end
       exit
     elsif ARGV.first == '--install-plugin'
       require 'erb'
@@ -39,9 +44,9 @@ END
     end
   end
 
-  def self.html_export
+  def self.html_export(markdown=false)
     require 'soywiki/html'
-    Html.export
+    Html.export(markdown)
   end
 end
 

--- a/soywiki.gemspec
+++ b/soywiki.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'haml'
+  s.add_dependency 'rdiscount'
 end


### PR DESCRIPTION
This adds simple support of markdown flavored pages.

usage:

soywiki --html --markdown
