### PR TITLE
For integration with Notational Velocity and LaunchBar: Skip *.txt  and "Notes & Settings" files in Linking-in pages search

### DIFF
--- a/bin/soywiki-pages-linking-in
+++ b/bin/soywiki-pages-linking-in
@@ -4,7 +4,7 @@ require 'soywiki'
 
 def contains_links_to?(file, page_title)
   return false unless File.file?(file)
-  return false if (file =~ /(\.swo|\.swp)$/ || file =~ /^\./)
+  return false if (file =~ /(\.swo|\.swp|\.txt|Notes\ &\ Settings)$/ || file =~ /^\./)
   body =   File.read(file)
   # '.' must be escaped in the regular expression to match literal
   body =~ /[\A\s\n\b]#{page_title.gsub(".", "\.")}\b/


### PR DESCRIPTION
Soywiki is amazing when used together with Notational Velocity (Mac application). LaunchBar is great for fast appending to text files.

But when using them ",M" "show linked pages" feature is broken because: 
- Notational Velocity needs to keep it's file named "Notes & Settings" in same folder as text files. Author is not going to change Notational Velocity as you can see here:
  https://github.com/scrod/nv/issues/226#comment_1101673
- LaunchBar  works only with ".txt" files.

I hope this small fix can be done for those using soywiki with Notational Velocity.
to achieve compatibility with i propose one line change.
