### PR TITLE
Avoid re-init with --separate-git-dir

### DIFF
--- a/lib/soywiki.vim
+++ b/lib/soywiki.vim
@@ -686,7 +686,8 @@ endfunc
 
 call s:global_mappings()
 
-if (!isdirectory(".git"))
+" also catch detched git directories
+if (!isdirectory(".git")&&!filereadable(".git"))
   call system("git init")
   echom "Created .git repository to store revisions"
 endif


### PR DESCRIPTION
This tiny patch avoids git reiniting the case that the `--separate-git-dir` option has been used.  Which is harmless, but a bit annoying.
