### PR TITLE
Use the HTTP regex to match a URL before opening it.

### DIFF
--- a/lib/soywiki.vim
+++ b/lib/soywiki.vim
@@ -574,7 +574,8 @@ func! s:expand(seamless, vertical)
 endfunc
 "------------------------------------------------------------------------
 func! s:open_href_under_cursor()
-  let href = expand("<cWORD>") 
+  let word = expand("<cWORD>")
+  let href = matchstr(word, s:http_link_pattern)
   let command = g:SoyWiki#browser_command . " '" . href . "' "
   call system(command)
   echom command 


### PR DESCRIPTION
I noticed that using markdown formatting, pressing enter on a URL won't work.

Example:
`The URL of [Google](http://www.google.de)`
results in the command
`gnome-open '[Google](http://www.google.de)'`

I  fixed that by matching the `http_link_pattern` on the word expansion to get rid of the non-URL stuff.
