### PR TITLE
Allow filesystem links in markdown syntax

### DIFF
--- a/lib/soywiki.vim
+++ b/lib/soywiki.vim
@@ -12,7 +12,7 @@ let mapleader = ','
 " This regex matches namedspaced WikiWords and unqualified WikiWords 
 let s:wiki_link_pattern =  '\C\m\<\([a-z0-9][[:alnum:]_]\+\.\)\?[A-Z][a-z]\+[A-Z0-9]\w*\>'
 let s:http_link_pattern = '\(https\?:[^ >\)\]]\+\)\|\[[^\]]\+\](\([^>\)\]]\+\))'
-let s:wiki_or_web_link_pattern =  '\C\<\([a-z0-9][[:alnum:]_]\+\.\)\?[A-Z][a-z]\+[A-Z0-9]\w*\>\|https\?:[^ >)\]]\+'
+let s:wiki_or_web_link_pattern = '\C\<\([a-z0-9][[:alnum:]_]\+\.\)\?[A-Z][a-z]\+[A-Z0-9]\w*\>\|https\?:[^ >)\]]\+'
 
 let s:rename_links_command = 'soywiki-rename '
 let s:find_pages_linking_in_command = 'soywiki-pages-linking-in '
@@ -681,8 +681,17 @@ endfunc
 func! s:highlight_wikiwords()
   if (s:is_wiki_page()) 
     "syntax clear
-    exe "syn match Comment /". s:wiki_link_pattern. "/"
-    exe "syn match Constant /". s:http_link_pattern . "/"
+    exe "syn match wikiLink /". s:wiki_link_pattern. "/"
+    exe "syn match externalLink /".s:http_link_pattern."/ contains=mdTitleRegion,mdRefRegion"
+    exe "syn region mdTitleRegion start='\\[' end='\\]' contains=mdTitle contained"
+    exe "syn region mdRefRegion start='(' end=')' contains=mdRef contained"
+    exe "syn match mdTitle /[^\]\[]/ contained"
+    exe "syn match mdRef /[^)(]/ contained"
+    exe "hi link externalLink Constant"
+    exe "hi link mdTitleRegion Constant"
+    exe "hi link mdRefRegion Constant"
+    exe "hi link mdRef Constant"
+    exe "hi link wikiLink Comment"
   endif
 endfunc
 


### PR DESCRIPTION
I really needed to link to files in the local filesystem. Use case is an index for a personal library of PDF files. I like to collect my notes in soywiki, and be able to open the relevant PDF file with a few keypresses.

Since soywiki already uses open/xdg-open to process links, I simply extended the regular expression for HTTP links to match markdown syntax, no matter whether the href includes HTTP or not, i.e. `[My PDF](../../library/research/pertinent.pdf)` is now matched.

Additionally, I changed the syntax highlighting to not highlight the complete markdown syntax, but only the URL part, as to emulate the behaviour from before.

This might be to specific to my needs and need some addional changes.
I'd just be happy to get some feedback whether supporting relative links is considered a useful feature.
