### PR TITLE
fix library loading for non-rbenv users.

### DIFF
--- a/bin/soywiki-expand
+++ b/bin/soywiki-expand
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'soywiki'
-require 'expander'
+require 'soywiki/expander'
 
 repo_path, mode, file = *ARGV
 expander = Soywiki::Expander.new(repo_path, mode, file)

--- a/bin/soywiki-rename
+++ b/bin/soywiki-rename
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 require 'soywiki'
-require 'renamer'
+require 'soywiki/renamer'
 
 repo_path, old_name, new_name = *ARGV
 repo_path = Pathname.new(repo_path)


### PR DESCRIPTION
This should fix soywiki `0.9.8.1` for **rvm** (or more general non-rbenv users).

(and it should finally fix #38)

@RobrechtDR i've released a pre version of `0.9.8.2` containing this patch, could you please try this and
see if it works for you?

You can install it with `gem install soywiki --pre`
